### PR TITLE
Mention the DEBUG environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ objinsync pull --once s3://bucket/keyprefix ./localdir
 To use with [Minio](https://docs.min.io/) instead of S3, you can set
 `--s3-endpoint` and `--disable-ssl` flags for `pull` command as you see fit.
 
+---
+
+Enable debug logs by setting the `DEBUG` environment variable `DEBUG=1 objinsync pull ...`
+
 
 Installation
 ------------


### PR DESCRIPTION
I found out about the `DEBUG` env var from [this issue](https://github.com/scribd/objinsync/issues/7). I think it could be useful to mention it in the readme since it might be able to help others if they encounter any issues. 