### PR TITLE
Add interval flag for configuring the pull interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ objinsync pull --once s3://bucket/keyprefix ./localdir
 To use with [Minio](https://docs.min.io/) instead of S3, you can set
 `--s3-endpoint` and `--disable-ssl` flags for `pull` command as you see fit.
 
+The `-i` or `--interval` flags allows to configure the pull time interval, which is 5 seconds by default:
+
+```bash
+objinsync pull --interval 20s s3://bucket/keyprefix ./localdir
+```
+
 ---
 
 Enable debug logs by setting the `DEBUG` environment variable `DEBUG=1 objinsync pull ...`

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	FlagDefaultFileMode = "0664"
 	FlagS3Endpoint      = ""
 	FlagDisableSSL      = false
+	FlagPullInterval    = time.Second * 5
 
 	metricsSyncTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: "objinsync",
@@ -98,7 +99,7 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			remoteUri := args[0]
 			localDir := args[1]
-			interval := time.Second * 5
+			interval := FlagPullInterval
 
 			puller, err := sync.NewPuller(remoteUri, localDir)
 			if err != nil {
@@ -177,6 +178,8 @@ func main() {
 		&FlagDefaultFileMode, "default-file-mode", "m", "0664", "default mode to use for creating local file")
 	pullCmd.PersistentFlags().StringVarP(
 		&FlagS3Endpoint, "s3-endpoint", "", "", "override endpoint to use for remote object store (e.g. minio)")
+	pullCmd.PersistentFlags().DurationVarP(
+		&FlagPullInterval, "interval", "i", time.Second * 5, "Interval between remote storage pulls")
 
 	rootCmd.AddCommand(pullCmd)
 	rootCmd.Execute()


### PR DESCRIPTION
This PR is in relation to #10.

It allows the configuration of the pull interval using the `--interval` or `-i` flag:

```bash
objinsync pull --interval 20s s3://bucket/keyprefix ./localdir
```