### PR TITLE
add "credential" parameter for the minio AK/SK setting

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 	FlagScratch         bool
 	FlagDefaultFileMode = "0664"
 	FlagS3Endpoint      = ""
+	FlagS3Credential    = ""
 	FlagDisableSSL      = false
 	FlagPullInterval    = time.Second * 5
 
@@ -107,6 +108,7 @@ func main() {
 			}
 			puller.DisableSSL = FlagDisableSSL
 			puller.S3Endpoint = FlagS3Endpoint
+			puller.Credential = FlagS3Credential
 			if FlagExclude != nil {
 				puller.AddExcludePatterns(FlagExclude)
 			}
@@ -179,7 +181,10 @@ func main() {
 	pullCmd.PersistentFlags().StringVarP(
 		&FlagS3Endpoint, "s3-endpoint", "", "", "override endpoint to use for remote object store (e.g. minio)")
 	pullCmd.PersistentFlags().DurationVarP(
-		&FlagPullInterval, "interval", "i", time.Second * 5, "Interval between remote storage pulls")
+		&FlagPullInterval, "interval", "i", time.Second*5, "Interval between remote storage pulls")
+
+	pullCmd.PersistentFlags().StringVarP(
+		&FlagS3Credential, "credential", "", "", "ACCESSKEYID/SECRETACCESSKEY for minio server, parameter format like: ak,sk. which use comma separated")
 
 	rootCmd.AddCommand(pullCmd)
 	rootCmd.Execute()

--- a/pkg/sync/pull.go
+++ b/pkg/sync/pull.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -103,6 +104,7 @@ type Puller struct {
 	LocalDir   string
 	DisableSSL bool
 	S3Endpoint string
+	Credential string
 
 	workingDir  string
 	defaultMode os.FileMode
@@ -318,6 +320,12 @@ func (self *Puller) Pull() string {
 		s3Config.Endpoint = aws.String(self.S3Endpoint)
 		s3Config.S3ForcePathStyle = aws.Bool(true)
 	}
+	if self.Credential != "" {
+		var keys = strings.Split(self.Credential, ",")
+		s3Config.Credentials = credentials.NewStaticCredentials(keys[0], keys[1], "")
+		l.Infow("Set the credentials", "AK=", keys[0], "SK=", keys[1])
+	}
+
 	svc := s3.New(sess, s3Config)
 
 	downloader := s3manager.NewDownloaderWithClient(svc)


### PR DESCRIPTION
usage for "credential" for minio server:
objinsync pull --interval 10s --disable-ssl --s3-endpoint http://pubip:port --credential "minioadmin,minioadmin"  s3://buckets/ ./sync/