### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,7 +21,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     - name: Run test
       run: make test
@@ -45,7 +45,7 @@ jobs:
         password: ${{ secrets.SCRIBDBOT_GH_CONTAINER_REGISTRY_TOKEN }}
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     # required for the changelog to work correctly
     - name: Unshallow

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: 1.20
       id: go
@@ -38,7 +38,7 @@ jobs:
     steps:
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: scribdbot
@@ -52,13 +52,13 @@ jobs:
       run: git fetch --prune --unshallow
 
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v6
       with:
         go-version: 1.20
       id: go
 
     - name: Run goreleaser
-      uses: goreleaser/goreleaser-action@v5
+      uses: goreleaser/goreleaser-action@v7
       with:
         version: latest
         args: release --rm-dist


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `actions/checkout@v2` → `actions/checkout@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates GitHub Actions versions in the CI/CD workflow; behavior should be unchanged aside from action implementation updates.
> 
> **Overview**
> Updates the `CI/CD` GitHub Actions workflow to newer action major versions to avoid deprecated Node.js runtimes.
> 
> Specifically bumps `actions/setup-go` to `@v6`, `actions/checkout` to `@v6`, `docker/login-action` to `@v4`, and `goreleaser/goreleaser-action` to `@v7` for both the test and release jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28f86cdbd84a48c876fece99556d9de6a60c411b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->